### PR TITLE
Use `c_char` instead of `i8` for char buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate libftdi1_sys as ftdic;
 
 pub use ftdic::ftdi_eeprom_value;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 use std::marker::PhantomData;
 use std::os::raw;
 use std::pin::Pin;
@@ -448,9 +448,9 @@ impl Device {
             self.load_eeprom_data()?;
         }
 
-        let mut manufacturer_buf = [0i8; 100];
-        let mut description_buf = [0i8; 100];
-        let mut serial_buf = [0i8; 100];
+        let mut manufacturer_buf = [0 as c_char; 100];
+        let mut description_buf = [0 as c_char; 100];
+        let mut serial_buf = [0 as c_char; 100];
 
         let rc = unsafe { ftdic::ftdi_read_eeprom(self.context.get_ftdi_context()) };
         self.context.check_ftdi_error(rc)?;
@@ -518,9 +518,9 @@ pub fn list_devices() -> Result<Vec<DeviceInfo>> {
     context.check_ftdi_error(rc)?;
 
     let mut devices = Vec::with_capacity(rc as usize);
-    let mut manufacturer_buf = [0i8; 100];
-    let mut description_buf = [0i8; 100];
-    let mut serial_buf = [0i8; 100];
+    let mut manufacturer_buf = [0 as c_char; 100];
+    let mut description_buf = [0 as c_char; 100];
+    let mut serial_buf = [0 as c_char; 100];
 
     let mut curdev = device_list;
     while !curdev.is_null() {


### PR DESCRIPTION
When trying to compile this library for arm64 I ran into several of these errors: expected raw pointer `*mut u8`
found raw pointer `*mut i8`

While the code correctly uses `CString` it uses `i8` as a type for chars which is only correct on X86. The char type on ARM and some other platforms is `u8`. `c_char` takes these platform differences into account.